### PR TITLE
Fix inconsistent event API

### DIFF
--- a/src/main/java/com/vaadin/flow/component/upload/FinishedEvent.java
+++ b/src/main/java/com/vaadin/flow/component/upload/FinishedEvent.java
@@ -92,7 +92,7 @@ public class FinishedEvent extends ComponentEvent<Upload> {
      *
      * @return the length.
      */
-    public long getLength() {
+    public long getContentLength() {
         return length;
     }
 

--- a/src/main/java/com/vaadin/flow/component/upload/StartedEvent.java
+++ b/src/main/java/com/vaadin/flow/component/upload/StartedEvent.java
@@ -64,7 +64,7 @@ public class StartedEvent extends ComponentEvent<Upload> {
      *
      * @return the filename.
      */
-    public String getFilename() {
+    public String getFileName() {
         return filename;
     }
 


### PR DESCRIPTION
Unify the usage of getFileName() and getContentLenght()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload-flow/30)
<!-- Reviewable:end -->
