### PR TITLE
Fix inverted file name and mime type in file data

### DIFF
--- a/src/main/java/com/vaadin/flow/component/upload/receivers/FileData.java
+++ b/src/main/java/com/vaadin/flow/component/upload/receivers/FileData.java
@@ -21,13 +21,13 @@ import java.io.OutputStream;
  * Class containing file information for upload.
  */
 public class FileData {
-    private final String mimeType, fileName;
+    private final String fileName, mimeType;
     private final OutputStream outputBuffer;
 
-    public FileData(String mimeType, String fileName,
+    public FileData(String fileName, String mimeType,
             OutputStream outputBuffer) {
-        this.mimeType = mimeType;
         this.fileName = fileName;
+        this.mimeType = mimeType;
         this.outputBuffer = outputBuffer;
     }
 


### PR DESCRIPTION
All callers pass file name as first argument to build file data but it expects mime type as first argument.
Inverted mime type and file name in the constructor of file data to provide correct information in getters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload-flow/37)
<!-- Reviewable:end -->
