### PR TITLE
WIP: Add file index to event constructors

### DIFF
--- a/src/main/java/com/vaadin/flow/component/upload/FailedEvent.java
+++ b/src/main/java/com/vaadin/flow/component/upload/FailedEvent.java
@@ -35,12 +35,14 @@ public class FailedEvent extends FinishedEvent {
      *            the MIME type of the received file.
      * @param length
      *            the number of uploaded bytes
+     * @param index
+     *            the index of the received file
      * @param reason
      *            exception that failed the upload
      */
     public FailedEvent(Upload source, String filename, String MIMEType,
-            long length, Exception reason) {
-        this(source, filename, MIMEType, length);
+            long length, int index, Exception reason) {
+        this(source, filename, MIMEType, length, index);
         this.reason = reason;
     }
 
@@ -54,10 +56,12 @@ public class FailedEvent extends FinishedEvent {
      *            the MIME type of the received file.
      * @param length
      *            the number of uploaded bytes
+     * @param index
+     *            the index of the received file
      */
     public FailedEvent(Upload source, String filename, String MIMEType,
-            long length) {
-        super(source, filename, MIMEType, length);
+            long length, int index) {
+        super(source, filename, MIMEType, length, index);
     }
 
     /**

--- a/src/main/java/com/vaadin/flow/component/upload/FinishedEvent.java
+++ b/src/main/java/com/vaadin/flow/component/upload/FinishedEvent.java
@@ -43,6 +43,11 @@ public class FinishedEvent extends ComponentEvent<Upload> {
     private final String fileName;
 
     /**
+     * Received file index.
+     */
+    private final int index;
+
+    /**
      * @param source
      *            the source of the file.
      * @param fileName
@@ -51,13 +56,16 @@ public class FinishedEvent extends ComponentEvent<Upload> {
      *            the MIME type of the received file.
      * @param length
      *            the length of the received file.
+     * @param index
+     *            the index of the received file
      */
     public FinishedEvent(Upload source, String fileName, String MIMEType,
-            long length) {
+            long length, int index) {
         super(source, false);
         type = MIMEType;
         this.fileName = fileName;
         this.length = length;
+        this.index = index;
     }
 
     /**
@@ -94,6 +102,13 @@ public class FinishedEvent extends ComponentEvent<Upload> {
      */
     public long getContentLength() {
         return length;
+    }
+
+    /**
+     * @return the index of the file that is being uploaded
+     */
+    public int getIndex() {
+        return index;
     }
 
 }

--- a/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
+++ b/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
@@ -847,15 +847,18 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
         private final JsonObject detail;
         private final JsonObject detailXhr;
         private final JsonObject detailFile;
+        private final int index;
 
         public UploadAbortEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.xhr") JsonObject detailXhr,
-                @EventData("event.detail.file") JsonObject detailFile) {
+                @EventData("event.detail.file") JsonObject detailFile,
+                @EventData("event.detail.index") int index) {
             super(source, fromClient);
             this.detail = detail;
             this.detailXhr = detailXhr;
             this.detailFile = detailFile;
+            this.index = index;
         }
 
         public JsonObject getDetail() {
@@ -868,6 +871,10 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
 
         public JsonObject getDetailFile() {
             return detailFile;
+        }
+
+        public int getIndex() {
+            return index;
         }
     }
 
@@ -893,17 +900,20 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
         private final JsonObject detailXhr;
         private final JsonObject detailFile;
         private final JsonObject detailFileUploadTarget;
+        private final int index;
 
         public UploadBeforeEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.xhr") JsonObject detailXhr,
                 @EventData("event.detail.file") JsonObject detailFile,
-                @EventData("event.detail.file.uploadTarget") JsonObject detailFileUploadTarget) {
+                @EventData("event.detail.file.uploadTarget") JsonObject detailFileUploadTarget,
+                @EventData("event.detail.index") int index) {
             super(source, fromClient);
             this.detail = detail;
             this.detailXhr = detailXhr;
             this.detailFile = detailFile;
             this.detailFileUploadTarget = detailFileUploadTarget;
+            this.index = index;
         }
 
         public JsonObject getDetail() {
@@ -920,6 +930,10 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
 
         public JsonObject getDetailFileUploadTarget() {
             return detailFileUploadTarget;
+        }
+
+        public int getIndex() {
+            return index;
         }
     }
 
@@ -944,15 +958,18 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
         private final JsonObject detail;
         private final JsonObject detailXhr;
         private final JsonObject detailFile;
+        private final int index;
 
         public UploadErrorEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.xhr") JsonObject detailXhr,
-                @EventData("event.detail.file") JsonObject detailFile) {
+                @EventData("event.detail.file") JsonObject detailFile,
+                @EventData("event.detail.index") int index) {
             super(source, fromClient);
             this.detail = detail;
             this.detailXhr = detailXhr;
             this.detailFile = detailFile;
+            this.index = index;
         }
 
         public JsonObject getDetail() {
@@ -965,6 +982,10 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
 
         public JsonObject getDetailFile() {
             return detailFile;
+        }
+
+        public int getIndex() {
+            return index;
         }
     }
 
@@ -989,15 +1010,18 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
         private final JsonObject detail;
         private final JsonObject detailXhr;
         private final JsonObject detailFile;
+        private final int index;
 
         public UploadProgressEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.xhr") JsonObject detailXhr,
-                @EventData("event.detail.file") JsonObject detailFile) {
+                @EventData("event.detail.file") JsonObject detailFile,
+                @EventData("event.detail.index") int index) {
             super(source, fromClient);
             this.detail = detail;
             this.detailXhr = detailXhr;
             this.detailFile = detailFile;
+            this.index = index;
         }
 
         public JsonObject getDetail() {
@@ -1010,6 +1034,10 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
 
         public JsonObject getDetailFile() {
             return detailFile;
+        }
+
+        public int getIndex() {
+            return index;
         }
     }
 
@@ -1035,17 +1063,20 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
         private final JsonObject detailXhr;
         private final JsonObject detailFile;
         private final JsonObject detailFormData;
+        private final int index;
 
         public UploadRequestEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.xhr") JsonObject detailXhr,
                 @EventData("event.detail.file") JsonObject detailFile,
-                @EventData("event.detail.formData") JsonObject detailFormData) {
+                @EventData("event.detail.formData") JsonObject detailFormData,
+                @EventData("event.detail.index") int index) {
             super(source, fromClient);
             this.detail = detail;
             this.detailXhr = detailXhr;
             this.detailFile = detailFile;
             this.detailFormData = detailFormData;
+            this.index = index;
         }
 
         public JsonObject getDetail() {
@@ -1062,6 +1093,10 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
 
         public JsonObject getDetailFormData() {
             return detailFormData;
+        }
+
+        public int getIndex() {
+            return index;
         }
     }
 
@@ -1086,15 +1121,18 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
         private final JsonObject detail;
         private final JsonObject detailXhr;
         private final JsonObject detailFile;
+        private final int index;
 
         public UploadResponseEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.xhr") JsonObject detailXhr,
-                @EventData("event.detail.file") JsonObject detailFile) {
+                @EventData("event.detail.file") JsonObject detailFile,
+                @EventData("event.detail.index") int index) {
             super(source, fromClient);
             this.detail = detail;
             this.detailXhr = detailXhr;
             this.detailFile = detailFile;
+            this.index = index;
         }
 
         public JsonObject getDetail() {
@@ -1107,6 +1145,10 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
 
         public JsonObject getDetailFile() {
             return detailFile;
+        }
+
+        public int getIndex() {
+            return index;
         }
     }
 
@@ -1131,15 +1173,18 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
         private final JsonObject detail;
         private final JsonObject detailXhr;
         private final JsonObject detailFile;
+        private final int index;
 
         public UploadRetryEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.xhr") JsonObject detailXhr,
-                @EventData("event.detail.file") JsonObject detailFile) {
+                @EventData("event.detail.file") JsonObject detailFile,
+                @EventData("event.detail.index") int index) {
             super(source, fromClient);
             this.detail = detail;
             this.detailXhr = detailXhr;
             this.detailFile = detailFile;
+            this.index = index;
         }
 
         public JsonObject getDetail() {
@@ -1152,6 +1197,10 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
 
         public JsonObject getDetailFile() {
             return detailFile;
+        }
+
+        public int getIndex() {
+            return index;
         }
     }
 
@@ -1176,15 +1225,18 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
         private final JsonObject detail;
         private final JsonObject detailXhr;
         private final JsonObject detailFile;
+        private final int index;
 
         public UploadStartEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.xhr") JsonObject detailXhr,
-                @EventData("event.detail.file") JsonObject detailFile) {
+                @EventData("event.detail.file") JsonObject detailFile,
+                @EventData("event.detail.index") int index) {
             super(source, fromClient);
             this.detail = detail;
             this.detailXhr = detailXhr;
             this.detailFile = detailFile;
+            this.index = index;
         }
 
         public JsonObject getDetail() {
@@ -1197,6 +1249,10 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
 
         public JsonObject getDetailFile() {
             return detailFile;
+        }
+
+        public int getIndex() {
+            return index;
         }
     }
 
@@ -1221,15 +1277,18 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
         private final JsonObject detail;
         private final JsonObject detailXhr;
         private final JsonObject detailFile;
+        private final int index;
 
         public UploadSuccessEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.xhr") JsonObject detailXhr,
-                @EventData("event.detail.file") JsonObject detailFile) {
+                @EventData("event.detail.file") JsonObject detailFile,
+                @EventData("event.detail.index") int index) {
             super(source, fromClient);
             this.detail = detail;
             this.detailXhr = detailXhr;
             this.detailFile = detailFile;
+            this.index = index;
         }
 
         public JsonObject getDetail() {
@@ -1242,6 +1301,10 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
 
         public JsonObject getDetailFile() {
             return detailFile;
+        }
+
+        public int getIndex() {
+            return index;
         }
     }
 

--- a/src/main/java/com/vaadin/flow/component/upload/NoInputStreamEvent.java
+++ b/src/main/java/com/vaadin/flow/component/upload/NoInputStreamEvent.java
@@ -30,10 +30,12 @@ public class NoInputStreamEvent extends FailedEvent {
      *            the MIME type of the received file.
      * @param length
      *            the length of the received file.
+     * @param index
+     *            the index of the received file
      */
     public NoInputStreamEvent(Upload source, String filename, String MIMEType,
-            long length) {
-        super(source, filename, MIMEType, length);
+            long length, int index) {
+        super(source, filename, MIMEType, length, index);
     }
 
 }

--- a/src/main/java/com/vaadin/flow/component/upload/NoOutputStreamEvent.java
+++ b/src/main/java/com/vaadin/flow/component/upload/NoOutputStreamEvent.java
@@ -30,9 +30,11 @@ public class NoOutputStreamEvent extends FailedEvent {
      *            the MIME type of the received file.
      * @param length
      *            the length of the received file.
+     * @param index
+     *            the index of the received file
      */
     public NoOutputStreamEvent(Upload source, String filename, String MIMEType,
-            long length) {
-        super(source, filename, MIMEType, length);
+            long length, int index) {
+        super(source, filename, MIMEType, length, index);
     }
 }

--- a/src/main/java/com/vaadin/flow/component/upload/ProgressUpdateEvent.java
+++ b/src/main/java/com/vaadin/flow/component/upload/ProgressUpdateEvent.java
@@ -35,6 +35,11 @@ public class ProgressUpdateEvent extends ComponentEvent<Upload> {
     private final long contentLength;
 
     /**
+     * Received file index.
+     */
+    private final int index;
+
+    /**
      * Event constructor method to construct a new progress event.
      *
      * @param source
@@ -43,12 +48,15 @@ public class ProgressUpdateEvent extends ComponentEvent<Upload> {
      *            bytes transferred
      * @param contentLength
      *            total size of file currently being uploaded, -1 if unknown
+     * @param index
+     *            the index of the file being uploaded
      */
     public ProgressUpdateEvent(Upload source, long readBytes,
-            long contentLength) {
+            long contentLength, int index) {
         super(source, false);
         this.readBytes = readBytes;
         this.contentLength = contentLength;
+        this.index = index;
     }
 
     /**
@@ -77,4 +85,12 @@ public class ProgressUpdateEvent extends ComponentEvent<Upload> {
     public long getContentLength() {
         return contentLength;
     }
+
+    /**
+     * @return the index of the file that is being uploaded
+     */
+    public int getIndex() {
+        return index;
+    }
+
 }

--- a/src/main/java/com/vaadin/flow/component/upload/StartedEvent.java
+++ b/src/main/java/com/vaadin/flow/component/upload/StartedEvent.java
@@ -30,6 +30,10 @@ public class StartedEvent extends ComponentEvent<Upload> {
      * Length of the received file.
      */
     private final long length;
+    /**
+     * Index of the received file.
+     */
+    private final int index;
 
     /**
      *
@@ -41,13 +45,16 @@ public class StartedEvent extends ComponentEvent<Upload> {
      *            the MIME type of the received file.
      * @param contentLength
      *            the length of the received file.
+     * @param index
+     *            the index of the received file.
      */
     public StartedEvent(Upload source, String filename, String MIMEType,
-            long contentLength) {
+            long contentLength, int index) {
         super(source, false);
         this.filename = filename;
         type = MIMEType;
         length = contentLength;
+        this.index = index;
     }
 
     /**
@@ -82,6 +89,13 @@ public class StartedEvent extends ComponentEvent<Upload> {
      */
     public long getContentLength() {
         return length;
+    }
+
+    /**
+     * @return the index of the file that is being uploaded
+     */
+    public int getIndex() {
+        return index;
     }
 
 }

--- a/src/main/java/com/vaadin/flow/component/upload/SucceededEvent.java
+++ b/src/main/java/com/vaadin/flow/component/upload/SucceededEvent.java
@@ -31,11 +31,13 @@ public class SucceededEvent extends FinishedEvent {
      * @param MIMEType
      *            the MIME type of the received file.
      * @param length
-     *            the length of the received file.
+     *            the length of the received file
+     * @param index
+     *            the index of the received file
      */
     public SucceededEvent(Upload source, String filename, String MIMEType,
-            long length) {
-        super(source, filename, MIMEType, length);
+            long length, int index) {
+        super(source, filename, MIMEType, length, index);
     }
 
 }

--- a/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -100,7 +100,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
     /**
      * Limit of files to upload, by default it is unlimited. If the value is set
      * to one, the native file browser will prevent selecting multiple files.
-     * 
+     *
      * @param maxFiles
      *            the maximum number of files allowed for the user to select
      */
@@ -111,7 +111,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
     /**
      * Gets the maximum number of files allowed for the user to select to
      * upload.
-     * 
+     *
      * @return the maximum number of files
      */
     public int getMaxFiles() {
@@ -122,7 +122,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      * Specifies the maximum file size in bytes allowed to upload. Notice that
      * it is a client-side constraint, which will be checked before sending the
      * request.
-     * 
+     *
      * @param maxFileSize
      *            the maximum file size in bytes
      */
@@ -132,7 +132,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
 
     /**
      * Gets the maximum allowed file size in the client-side, in bytes.
-     * 
+     *
      * @return the maximum file size in bytes
      */
     public int getMaxFileSize() {
@@ -142,7 +142,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
     /**
      * When <code>false</code>, it prevents uploads from triggering immediately
      * upon adding file(s). The default is <code>true</code>.
-     * 
+     *
      * @param autoUpload
      *            <code>true</code> to allow uploads to start immediately after
      *            selecting files, <code>false</code> otherwise.
@@ -153,7 +153,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
 
     /**
      * Gets the auto upload status.
-     * 
+     *
      * @return <code>true</code> if the upload of files should start immediately
      *         after they are selected, <code>false</code> otherwise.
      */
@@ -167,7 +167,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      * mobile devices do not support drag events in general. Setting it
      * <code>true</code> means that drop is enabled even in touch-devices, and
      * <code>false</code> disables drop in all devices.
-     * 
+     *
      * @param dropAllowed
      *            <code>true</code> to allow file dropping, <code>false</code>
      *            otherwise
@@ -180,7 +180,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      * Gets whether file dropping is allowed or not. By default it's enabled in
      * desktop and disabled in touch devices because mobile devices do not
      * support drag events in general.
-     * 
+     *
      * @return <code>true</code> if file dropping is allowed, <code>false</code>
      *         otherwise.
      */
@@ -196,7 +196,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      * <p>
      * Example: <code>"video/*","image/tiff"</code> or
      * <code>".pdf","audio/mp3"</code>
-     * 
+     *
      * @param acceptedFileTypes
      *            the allowed file types to be uploaded, or <code>null</code> to
      *            clear any restrictions
@@ -211,7 +211,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
 
     /**
      * Gets the list of accepted file types for upload.
-     * 
+     *
      * @return a list of allowed file types, never <code>null</code>.
      */
     public List<String> getAcceptedFileTypes() {
@@ -225,7 +225,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
     /**
      * Sets the component as the actionable button inside the upload component,
      * that starts the upload of the selected files.
-     * 
+     *
      * @param uploadButton
      *            the component to be clicked by the user to start the upload,
      *            or <code>null</code> to clear it
@@ -239,7 +239,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
 
     /**
      * Gets the component set as the upload button for the upload, if any.
-     * 
+     *
      * @return the actionable button, or <code>null</code> if none was set
      */
     public Component getUploadButton() {
@@ -249,7 +249,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
     /**
      * Sets the component to show as a message to the user to drop files in the
      * upload component. Despite of the name, the label can be any component.
-     * 
+     *
      * @param dropLabel
      *            the label to show for the users when it's possible drop files,
      *            or <code>null</code> to clear it
@@ -263,7 +263,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
 
     /**
      * Gets the component set as the drop label, if any.
-     * 
+     *
      * @return the drop label component, or <code>null</code> if none was set
      */
     public Component getDropLabel() {
@@ -274,7 +274,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      * Sets the component to show as the drop label icon. The icon is visible
      * when the user can drop files to this upload component. Despite of the
      * name, the drop label icon can be any component.
-     * 
+     *
      * @param dropLabelIcon
      *            the label icon to show for the users when it's possible to
      *            drop files, or <code>null</code> to cleat it
@@ -288,7 +288,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
 
     /**
      * Gets the component set as the drop label icon, if any.
-     * 
+     *
      * @return the drop label icon component, or <code>null</code> if none was
      *         set
      */
@@ -350,33 +350,33 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
     }
 
     private void fireStarted(String filename, String MIMEType,
-            long contentLength) {
-        fireEvent(new StartedEvent(this, filename, MIMEType, contentLength));
+            long contentLength, int index) {
+        fireEvent(new StartedEvent(this, filename, MIMEType, contentLength, index));
     }
 
     private void fireUploadInterrupted(String filename, String MIMEType,
-            long length) {
-        fireEvent(new FailedEvent(this, filename, MIMEType, length));
+            long length, int index) {
+        fireEvent(new FailedEvent(this, filename, MIMEType, length, index));
     }
 
     private void fireNoInputStream(String filename, String MIMEType,
-            long length) {
-        fireEvent(new NoInputStreamEvent(this, filename, MIMEType, length));
+            long length, int index) {
+        fireEvent(new NoInputStreamEvent(this, filename, MIMEType, length, index));
     }
 
     private void fireNoOutputStream(String filename, String MIMEType,
-            long length) {
-        fireEvent(new NoOutputStreamEvent(this, filename, MIMEType, length));
+            long length, int index) {
+        fireEvent(new NoOutputStreamEvent(this, filename, MIMEType, length, index));
     }
 
     private void fireUploadInterrupted(String filename, String MIMEType,
-            long length, Exception e) {
-        fireEvent(new FailedEvent(this, filename, MIMEType, length, e));
+            long length, int index, Exception e) {
+        fireEvent(new FailedEvent(this, filename, MIMEType, length, index, e));
     }
 
     private void fireUploadSuccess(String filename, String MIMEType,
-            long length) {
-        fireEvent(new SucceededEvent(this, filename, MIMEType, length));
+            long length, int index) {
+        fireEvent(new SucceededEvent(this, filename, MIMEType, length, index));
     }
 
     /**
@@ -386,9 +386,11 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      *            bytes received so far
      * @param contentLength
      *            actual size of the file being uploaded, if known
+     * @param index
+     *            the index of the file being uploaded
      */
-    protected void fireUpdateProgress(long totalBytes, long contentLength) {
-        fireEvent(new ProgressUpdateEvent(this, totalBytes, contentLength));
+    protected void fireUpdateProgress(long totalBytes, long contentLength, int index) {
+        fireEvent(new ProgressUpdateEvent(this, totalBytes, contentLength, index));
     }
 
     /**
@@ -567,7 +569,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
         @Override
         public void onProgress(StreamVariable.StreamingProgressEvent event) {
             upload.fireUpdateProgress(event.getBytesReceived(),
-                    event.getContentLength());
+                    event.getContentLength(), -1);
         }
 
         @Override
@@ -592,7 +594,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
             upload.startUpload();
             try {
                 upload.fireStarted(event.getFileName(), event.getMimeType(),
-                        event.getContentLength());
+                        event.getContentLength(), -1);
             } finally {
                 lastStartedEvent.addLast(event);
             }
@@ -602,7 +604,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
         public void streamingFinished(StreamVariable.StreamingEndEvent event) {
             try {
                 upload.fireUploadSuccess(event.getFileName(),
-                        event.getMimeType(), event.getContentLength());
+                        event.getMimeType(), event.getContentLength(), -1);
             } finally {
                 upload.endUpload();
             }
@@ -614,13 +616,13 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
                 Exception exception = event.getException();
                 if (exception instanceof NoInputStreamException) {
                     upload.fireNoInputStream(event.getFileName(),
-                            event.getMimeType(), 0);
+                            event.getMimeType(), 0, -1);
                 } else if (exception instanceof NoOutputStreamException) {
                     upload.fireNoOutputStream(event.getFileName(),
-                            event.getMimeType(), 0);
+                            event.getMimeType(), 0, -1);
                 } else {
                     upload.fireUploadInterrupted(event.getFileName(),
-                            event.getMimeType(), event.getBytesReceived(),
+                            event.getMimeType(), event.getBytesReceived(), -1,
                             exception);
                 }
             } finally {


### PR DESCRIPTION
This adds the uploaded file index to events, referring to the index of the file list of the web component:

- Should fix #100
- Depends on vaadin/vaadin-upload#290

Open issue: `DefaultStreamVariable` fires events of type [`StreamEvent`](https://github.com/vaadin/flow/blob/2a4c6e6e0455fb9ad7db1a423944971cb28dc636/flow-server/src/main/java/com/vaadin/flow/server/StreamVariable.java#L117) which does not have an index reference, so for now events are fired with index `-1`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload-flow/101)
<!-- Reviewable:end -->
