### PR TITLE
1.2.1 cherry-picks

### DIFF
--- a/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -379,6 +379,11 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
             long length) {
         fireEvent(new SucceededEvent(this, filename, MIMEType, length));
     }
+    
+    private void fireUploadFinish(String filename, String MIMEType,
+            long length) {
+        fireEvent(new FinishedEvent(this, filename, MIMEType, length));
+    }
 
     /**
      * Emit the progress event.
@@ -606,6 +611,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
                         event.getMimeType(), event.getContentLength());
             } finally {
                 upload.endUpload();
+                upload.fireUploadFinish(event.getFileName(), event.getMimeType(), event.getContentLength());
             }
         }
 
@@ -626,6 +632,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
                 }
             } finally {
                 upload.endUpload();
+                upload.fireUploadFinish(event.getFileName(), event.getMimeType(), event.getContentLength());
             }
         }
     }


### PR DESCRIPTION
Cherry-picks:
- Fix: Call FinishEvent after upload finishes. (#110)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload-flow/113)
<!-- Reviewable:end -->
