### PR TITLE
Expose fileRejectedListener

### DIFF
--- a/vaadin-upload-flow-demo/src/main/java/com/vaadin/flow/component/upload/demo/UploadView.java
+++ b/vaadin-upload-flow-demo/src/main/java/com/vaadin/flow/component/upload/demo/UploadView.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.upload.demo;
 
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.Paragraph;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
@@ -62,6 +64,7 @@ public class UploadView extends DemoView {
         createNonImmediateUpload();
         changeDefaultComponents();
         i18nSampleUpload();
+        createUploadWithFileConstraints();
     }
 
     private void createSimpleUpload() {
@@ -86,6 +89,31 @@ public class UploadView extends DemoView {
 
         addCard("Simple in memory receiver for single file upload", upload,
                 output);
+    }
+
+    private void createUploadWithFileConstraints() {
+        Div output = new Div();
+
+        //@formatter:off
+        // begin-source-example
+        // source-example-heading: Simple single file upload showing messages when file rejected
+        MemoryBuffer buffer = new MemoryBuffer();
+        Upload upload = new Upload(buffer);
+        upload.setMaxFiles(1);
+        upload.setDropLabel(new Label("Upload a 300 bytes file in .csv format"));
+        upload.setAcceptedFileTypes("text/csv");
+        upload.setMaxFileSize(300);
+
+        upload.addFileRejectedListener(event -> {
+            Paragraph component = new Paragraph();
+            showOutput(event.getDetail().toString(), component, output);
+        });
+        // end-source-example
+        //@formatter:on
+        upload.setId("test-upload");
+        output.setId("test-output");
+
+        addCard("Simple single file upload showing messages when file rejected", upload, output);
     }
 
     private void createSimpleMultiFileUpload() {

--- a/vaadin-upload-flow-demo/src/main/java/com/vaadin/flow/component/upload/demo/UploadView.java
+++ b/vaadin-upload-flow-demo/src/main/java/com/vaadin/flow/component/upload/demo/UploadView.java
@@ -107,7 +107,7 @@ public class UploadView extends DemoView {
 
         upload.addFileRejectedListener(event -> {
             Paragraph component = new Paragraph();
-            showOutput(event.getDetail().toString(), component, output);
+            showOutput(event.getErrorMessage(), component, output);
         });
         // end-source-example
         //@formatter:on

--- a/vaadin-upload-flow-demo/src/main/java/com/vaadin/flow/component/upload/demo/UploadView.java
+++ b/vaadin-upload-flow-demo/src/main/java/com/vaadin/flow/component/upload/demo/UploadView.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.upload.demo;
 
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.Paragraph;
+import java.nio.charset.StandardCharsets;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
@@ -266,13 +267,7 @@ public class UploadView extends DemoView {
     private Component createComponent(String mimeType, String fileName,
             InputStream stream) {
         if (mimeType.startsWith("text")) {
-            String text = "";
-            try {
-                text = IOUtils.toString(stream, "UTF-8");
-            } catch (IOException e) {
-                text = "exception reading stream";
-            }
-            return new Text(text);
+          return createTextComponent(stream);
         } else if (mimeType.startsWith("image")) {
             Image image = new Image();
             try {
@@ -309,7 +304,17 @@ public class UploadView extends DemoView {
 
     }
 
-    private void showOutput(String text, Component content,
+  private Component createTextComponent(InputStream stream) {
+    String text;
+    try {
+        text = IOUtils.toString(stream, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+        text = "exception reading stream";
+    }
+    return new Text(text);
+  }
+
+  private void showOutput(String text, Component content,
             HasComponents outputContainer) {
         HtmlComponent p = new HtmlComponent(Tag.P);
         p.getElement().setText(text);

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRejectedEvent.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRejectedEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.component.upload;
 
 import com.vaadin.flow.component.ComponentEvent;

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRejectedEvent.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/FileRejectedEvent.java
@@ -1,0 +1,34 @@
+package com.vaadin.flow.component.upload;
+
+import com.vaadin.flow.component.ComponentEvent;
+
+/**
+ * Sent when the file selected for upload doesn't meet the constraints specified on {@link Upload}
+ *
+ * @author Vaadin Ltd.
+ */
+public class FileRejectedEvent extends ComponentEvent<Upload> {
+
+  private String errorMessage;
+
+  /**
+   * Creates a new event using the given source and indicator whether the
+   * event originated from the client side or the server side.
+   *
+   * @param source       the source component
+   * @param errorMessage the error message
+   */
+  public FileRejectedEvent(Upload source, String errorMessage) {
+    super(source, true);
+    this.errorMessage = errorMessage;
+  }
+
+  /**
+   * Get the error message
+   *
+   * @return errorMessage
+   */
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+}

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.upload;
 
-import elemental.json.JsonString;
 import javax.annotation.Generated;
 
 import com.vaadin.flow.component.Component;

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.upload;
 
+import elemental.json.JsonString;
 import javax.annotation.Generated;
 
 import com.vaadin.flow.component.Component;
@@ -806,12 +807,12 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
             extends ComponentEvent<R> {
         private final JsonObject detail;
         private final JsonObject detailFile;
-        private final JsonObject detailError;
+        private final JsonString detailError;
 
         public FileRejectEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.file") JsonObject detailFile,
-                @EventData("event.detail.error") JsonObject detailError) {
+                @EventData("event.detail.error") JsonString detailError) {
             super(source, fromClient);
             this.detail = detail;
             this.detailFile = detailFile;
@@ -826,7 +827,7 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
             return detailFile;
         }
 
-        public JsonObject getDetailError() {
+        public JsonString getDetailError() {
             return detailError;
         }
     }

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
@@ -807,12 +807,12 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
             extends ComponentEvent<R> {
         private final JsonObject detail;
         private final JsonObject detailFile;
-        private final JsonString detailError;
+        private final String detailError;
 
         public FileRejectEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
                 @EventData("event.detail.file") JsonObject detailFile,
-                @EventData("event.detail.error") JsonString detailError) {
+                @EventData("event.detail.error") String detailError) {
             super(source, fromClient);
             this.detail = detail;
             this.detailFile = detailFile;
@@ -827,7 +827,7 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
             return detailFile;
         }
 
-        public JsonString getDetailError() {
+        public String getDetailError() {
             return detailError;
         }
     }

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -112,6 +112,13 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
       setReceiver(receiver);
     }
 
+    /**
+     * Add a finished listener that is informed on upload finished.
+     *
+     * @param listener
+     *            the listener
+     * @return a {@link Registration} for removing the event listener
+     */
     public Registration addUploadsFinishedListener(
             ComponentEventListener<UploadsFinishedEvent> listener) {
         return addListener(UploadsFinishedEvent.class, listener);

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -80,8 +80,9 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
         getElement().setAttribute("target", new StreamReceiver(
                 getElement().getNode(), "upload", getStreamVariable()));
 
-        DomEventListener uploadsFinishedListener = e -> {
-            JsonArray files = e.getEventData().getArray("element.files");
+      final String elementFiles = "element.files";
+      DomEventListener uploadsFinishedListener = e -> {
+            JsonArray files = e.getEventData().getArray(elementFiles);
 
             boolean isUploading = IntStream.range(0, files.length()).anyMatch(
                     index -> files.getObject(index).getBoolean("uploading"));
@@ -94,14 +95,9 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
 
         addUploadStartListener(e -> this.uploading = true);
         getElement().addEventListener("upload-success", uploadsFinishedListener)
-                .addEventData("element.files");
+                .addEventData(elementFiles);
         getElement().addEventListener("upload-error", uploadsFinishedListener)
-                .addEventData("element.files");
-    }
-
-    public Registration addUploadsFinishedListener(
-            ComponentEventListener<UploadsFinishedEvent> listener) {
-        return addListener(UploadsFinishedEvent.class, listener);
+                .addEventData(elementFiles);
     }
 
     /**
@@ -111,9 +107,14 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      *            receiver that handles the upload
      */
     public Upload(Receiver receiver) {
-        this();
+      this();
 
-        setReceiver(receiver);
+      setReceiver(receiver);
+    }
+
+    public Registration addUploadsFinishedListener(
+            ComponentEventListener<UploadsFinishedEvent> listener) {
+        return addListener(UploadsFinishedEvent.class, listener);
     }
 
     private StreamVariable getStreamVariable() {

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -75,7 +75,7 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
         addUploadSuccessListener(event -> {
         });
 
-        addFileRejectListener(event -> fireEvent(new FileRejectedEvent(this, event.getDetailError().getString())));
+        addFileRejectListener(event -> fireEvent(new FileRejectedEvent(this, event.getDetailError())));
 
         // If client aborts upload mark upload as interrupted on server also
         addUploadAbortListener(event -> interruptUpload());

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -386,39 +386,39 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
         return activeUploads > 0;
     }
 
-    private void fireStarted(String filename, String MIMEType,
+    private void fireStarted(String filename, String mimeType,
             long contentLength) {
-        fireEvent(new StartedEvent(this, filename, MIMEType, contentLength));
+        fireEvent(new StartedEvent(this, filename, mimeType, contentLength));
     }
 
-    private void fireUploadInterrupted(String filename, String MIMEType,
+    private void fireUploadInterrupted(String filename, String mimeType,
             long length) {
-        fireEvent(new FailedEvent(this, filename, MIMEType, length));
+        fireEvent(new FailedEvent(this, filename, mimeType, length));
     }
 
-    private void fireNoInputStream(String filename, String MIMEType,
+    private void fireNoInputStream(String filename, String mimeType,
             long length) {
-        fireEvent(new NoInputStreamEvent(this, filename, MIMEType, length));
+        fireEvent(new NoInputStreamEvent(this, filename, mimeType, length));
     }
 
-    private void fireNoOutputStream(String filename, String MIMEType,
+    private void fireNoOutputStream(String filename, String mimeType,
             long length) {
-        fireEvent(new NoOutputStreamEvent(this, filename, MIMEType, length));
+        fireEvent(new NoOutputStreamEvent(this, filename, mimeType, length));
     }
 
-    private void fireUploadInterrupted(String filename, String MIMEType,
+    private void fireUploadInterrupted(String filename, String mimeType,
             long length, Exception e) {
-        fireEvent(new FailedEvent(this, filename, MIMEType, length, e));
+        fireEvent(new FailedEvent(this, filename, mimeType, length, e));
     }
 
-    private void fireUploadSuccess(String filename, String MIMEType,
+    private void fireUploadSuccess(String filename, String mimeType,
             long length) {
-        fireEvent(new SucceededEvent(this, filename, MIMEType, length));
+        fireEvent(new SucceededEvent(this, filename, mimeType, length));
     }
 
-    private void fireUploadFinish(String filename, String MIMEType,
+    private void fireUploadFinish(String filename, String mimeType,
             long length) {
-        fireEvent(new FinishedEvent(this, filename, MIMEType, length));
+        fireEvent(new FinishedEvent(this, filename, mimeType, length));
     }
 
     private void fireUploadsFinish() {

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -55,7 +55,6 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
     private int activeUploads = 0;
     private boolean uploading;
 
-    private static final String I18N_PROPERTY = "i18n";
     private UploadI18N i18n;
 
     /**
@@ -84,13 +83,13 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
         DomEventListener uploadsFinishedListener = e -> {
             JsonArray files = e.getEventData().getArray("element.files");
 
-            boolean uploading = IntStream.range(0, files.length()).anyMatch(
+            boolean isUploading = IntStream.range(0, files.length()).anyMatch(
                     index -> files.getObject(index).getBoolean("uploading"));
 
-            if (this.uploading && !uploading) {
+            if (this.uploading && !isUploading) {
                 this.fireUploadsFinish();
             }
-            this.uploading = uploading;
+            this.uploading = isUploading;
         };
 
         addUploadStartListener(e -> this.uploading = true);

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -487,6 +487,20 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
         return addListener(SucceededEvent.class, listener);
     }
 
+
+    /**
+     * Adds a listener for {@code file-reject} events fired when a file cannot be added due to some constrains:
+     * {@code setMaxFileSize, setMaxFiles, setAcceptedFileTypes}
+     *
+     * @param listener
+     *            the listener
+     * @return a {@link Registration} for removing the event listener
+     */
+    public Registration addFileRejectedListener(
+            ComponentEventListener<FileRejectEvent<Upload>> listener) {
+        return addFileRejectListener(listener);
+    }
+
     /**
      * Return the current receiver.
      *

--- a/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -71,8 +71,11 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
         // Get a server round trip for upload error and success.
         addUploadErrorListener(event -> {
         });
+
         addUploadSuccessListener(event -> {
         });
+
+        addFileRejectListener(event -> fireEvent(new FileRejectedEvent(this, event.getDetailError().getString())));
 
         // If client aborts upload mark upload as interrupted on server also
         addUploadAbortListener(event -> interruptUpload());
@@ -504,8 +507,8 @@ public class Upload extends GeneratedVaadinUpload<Upload> implements HasSize {
      * @return a {@link Registration} for removing the event listener
      */
     public Registration addFileRejectedListener(
-            ComponentEventListener<FileRejectEvent<Upload>> listener) {
-        return addFileRejectListener(listener);
+            ComponentEventListener<FileRejectedEvent> listener) {
+        return addListener(FileRejectedEvent.class, listener);
     }
 
     /**


### PR DESCRIPTION
This exposes fileRejectedListener when the selected or dropped file(s) don't meet specified constrains in `Upload.setMaxFileSize`, `Upload.setMaxFiles`, `Upload.setAcceptedFileTypes` which would fix https://github.com/vaadin/vaadin-upload-flow/issues/107 

However, this relies on https://github.com/vaadin/vaadin-upload/pull/307 to be merged and `GeneratedVaadinUpload.FileRejectEvent` regenerated with `detailError` as a `JsonString` rather than an object because it causes a `ClassCastException` as the `event.detail.error` (as seen below) is actually a string, not an object

```Sending xhr message to server: {"csrfToken":"4f061cf6-cd5f-4d0e-8ffe-9f2816124637","rpc":[{"type":"event","node":5,"event":"file-reject","data":{"event.detail.error":"File is Too Big.","event.detail":{"file":{},"error":"File is Too Big."},"event.detail.file":{}}}],"syncId":1,"clientId":1}```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-upload-flow/146)
<!-- Reviewable:end -->
