### PR TITLE
refactor: use Java's nio for creating temporary files (CP: 1.0) (#181)

### DIFF
--- a/src/main/java/com/vaadin/flow/component/upload/receivers/AbstractFileBuffer.java
+++ b/src/main/java/com/vaadin/flow/component/upload/receivers/AbstractFileBuffer.java
@@ -30,17 +30,11 @@ public abstract class AbstractFileBuffer implements Serializable {
     private FileFactory factory;
 
     /**
-     * Constructor for creating a file buffer with the default file factory.
-     * <p>
-     * Files will be created using {@link File#createTempFile(String, String)}
-     * and have that build 'upload_tmpfile_{FILENAME}_{currentTimeMillis}'
+     * Constructor for creating a file buffer with the default temporary file
+     * factory.
      */
     public AbstractFileBuffer() {
-        factory = fileName -> {
-            final String tempFileName = "upload_tmpfile_" + fileName + "_"
-                    + System.currentTimeMillis();
-            return File.createTempFile(tempFileName, null);
-        };
+        factory = new TemporaryFileFactory();
     }
 
     /**
@@ -65,9 +59,7 @@ public abstract class AbstractFileBuffer implements Serializable {
             return new FileOutputStream(factory.createFile(fileName));
         } catch (IOException e) {
             getLogger().log(Level.SEVERE,
-                    "Failed to create file output stream for: '" + fileName
-                            + "'",
-                    e);
+                    "Failed to create temporary file output stream", e);
         }
         return null;
     }

--- a/src/main/java/com/vaadin/flow/component/upload/receivers/TempDirectory.java
+++ b/src/main/java/com/vaadin/flow/component/upload/receivers/TempDirectory.java
@@ -29,6 +29,9 @@ public final class TempDirectory {
      */
     private static class LazyHolder {
         static final TempDirectory INSTANCE = new TempDirectory();
+
+        private LazyHolder() {
+        }
     }
 
     public static Path getPath() {

--- a/src/main/java/com/vaadin/flow/component/upload/receivers/TempDirectory.java
+++ b/src/main/java/com/vaadin/flow/component/upload/receivers/TempDirectory.java
@@ -1,0 +1,41 @@
+package com.vaadin.flow.component.upload.receivers;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class TempDirectory {
+    private final Path path;
+
+    private TempDirectory() {
+        Path tempPath;
+        try {
+            tempPath = Files.createTempDirectory("temp_dir");
+        } catch (IOException e) {
+            getLogger().log(Level.SEVERE,
+                    "Failed to create temporary directory for upload component '",
+                    e);
+            tempPath = null;
+        }
+        path = tempPath;
+    }
+
+    /**
+     * This class is for having a thread-safe singleton object. please take a
+     * look here:
+     * https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom
+     */
+    private static class LazyHolder {
+        static final TempDirectory INSTANCE = new TempDirectory();
+    }
+
+    public static Path getPath() {
+        return LazyHolder.INSTANCE.path;
+    }
+
+    private Logger getLogger() {
+        return Logger.getLogger(this.getClass().getName());
+    }
+}

--- a/src/main/java/com/vaadin/flow/component/upload/receivers/TemporaryFileFactory.java
+++ b/src/main/java/com/vaadin/flow/component/upload/receivers/TemporaryFileFactory.java
@@ -1,0 +1,25 @@
+package com.vaadin.flow.component.upload.receivers;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class TemporaryFileFactory implements FileFactory {
+
+    /**
+     * Create a new temporary file
+     */
+    @Override
+    public File createFile(String fileName) throws IOException {
+
+        final String tempFileName = "upload_temp_file";
+        Path tempDirectory = TempDirectory.getPath();
+
+        if (tempDirectory == null) {
+            throw new IOException("Failed to create temp directory");
+        }
+        return Files.createTempFile(tempDirectory, tempFileName, "tmp")
+                .toFile();
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/upload/tests/TemporaryFileFactoryTest.java
+++ b/src/test/java/com/vaadin/flow/component/upload/tests/TemporaryFileFactoryTest.java
@@ -1,0 +1,23 @@
+package com.vaadin.flow.component.upload.tests;
+
+import com.vaadin.flow.component.upload.receivers.TemporaryFileFactory;
+import org.hamcrest.core.IsNot;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+public class TemporaryFileFactoryTest {
+
+    @Test
+    public void temporaryFileShouldNotContainFileName() throws IOException {
+        TemporaryFileFactory temporaryFileFactory = new TemporaryFileFactory();
+        File testFile = temporaryFileFactory.createFile("test");
+        String fileName = testFile.getName();
+
+        Assert.assertThat(fileName, IsNot.not(containsString("test")));
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/upload/tests/UploadSerializableTest.java
+++ b/src/test/java/com/vaadin/flow/component/upload/tests/UploadSerializableTest.java
@@ -12,7 +12,9 @@ public class UploadSerializableTest extends ClassesSerializableTest {
     protected Stream<String> getExcludedPatterns() {
 
         return Stream.concat(super.getExcludedPatterns(),
-                Stream.of("com\\.vaadin\\.flow\\.component\\.upload\\.Upload")//TODO Fix serialization
+                Stream.of("com\\.vaadin\\.flow\\.component\\.upload\\.Upload",
+                        "com\\.vaadin\\.flow\\.component\\.upload\\.receivers\\.TempDirectory",
+                        "com\\.vaadin\\.flow\\.component\\.upload\\.receivers\\.TempDirectory\\$LazyHolder")
         );
     }
 


### PR DESCRIPTION
This PR removes usage of old File API for creating temporary files with newer Files API. It also uses createTempDirectory in combination of createTempFile. It also removes usage of current time and also user supplied file name in creation of temporary file.

Related to: vaadin/flow-components#2254